### PR TITLE
Fix INSTALL.md: correct conda package names and channel

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,10 +14,22 @@ from source instead, see [BUILD.md](BUILD.md).
 - Miniconda installed at `/opt/miniconda3` with the Coot scientific
   libraries:
   ```sh
-  conda install -c conda-forge \
-    clipper-cif clipper-contrib clipper-core clipper-ccp4 \
-    clipper-mmdb clipper-minimol clipper-phs clipper-cns \
-    mmdb2 ssm
+  conda install --override-channels -c bioconda -c conda-forge \
+    clipper libccp4 mmdb2 ssm
+  ```
+  `bioconda/clipper` 2.1.20180802 is the CCP4 crystallography library;
+  it ships all the `libclipper-*.2.dylib` files Bandicoot links against
+  in a single package. (It is unrelated to the conda-forge "clipper"
+  CLIP-seq Python tool.) `--override-channels` bypasses the Anaconda
+  default channels (`pkgs/main`, `pkgs/r`), which now require Terms-of-
+  Service acceptance and will otherwise abort a non-interactive install.
+
+  If you don't already have Miniconda at that exact path:
+  ```sh
+  curl -fsSL -o /tmp/miniconda.sh \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+  sudo mkdir -p /opt/miniconda3 && sudo chown "$USER":staff /opt/miniconda3
+  bash /tmp/miniconda.sh -b -u -p /opt/miniconda3
   ```
 
 The prebuilt binary expects Homebrew and Miniconda at those exact
@@ -66,8 +78,10 @@ you launch from — clean those up if you want a fully clean removal.
   Homebrew package isn't installed, or Homebrew is at a non-standard
   prefix. Install the missing package, or rebuild from source pointed
   at your prefix.
-- **`dyld: Library not loaded: /opt/miniconda3/...`** — same, for
-  Miniconda. Install the missing conda package.
+- **`dyld: Library not loaded: /opt/miniconda3/lib/libclipper-...`** —
+  install `bioconda/clipper`. For `libccp4c` → `bioconda/libccp4`; for
+  `libmmdb2` → `bioconda/mmdb2`; for `libssm` → `bioconda/ssm`. All
+  four come from the requirements command above.
 - **A broken-image graphic appears on the splash, or "couldn't find
   pixmap file: bandicoot-splash.png"** — the bcoot wrapper failed to
   export `COOT_DATA_DIR` correctly. Make sure you launch through


### PR DESCRIPTION
## Summary
- Fixes the conda install command in INSTALL.md, which currently lists eight `clipper-*` packages on `conda-forge` that don't exist on any public channel. The actual library is `bioconda/clipper` 2.1.20180802 — a single package that bundles all the `libclipper-*.2.dylib` files Bandicoot links against. `libccp4` is also bioconda-only.
- Adds `--override-channels` so installs don't fail on Anaconda's new default-channels ToS prompt (`CondaToSNonInteractiveError`).
- Adds a short snippet showing how to install Miniconda to `/opt/miniconda3` (the path is required, and `/opt` is root-owned, so it needs one sudo step).
- Updates the dyld troubleshooting bullet to map each missing dylib to its actual bioconda package.

## Why
Following INSTALL.md as written today fails at the conda step:

```
PackagesNotFoundInChannelsError: The following packages are not available from current channels:
  - clipper-ccp4
```

(also `clipper-cif`, `clipper-contrib`, `clipper-core`, `clipper-mmdb`, `clipper-minimol`, `clipper-phs`, `clipper-cns` — none of those names exist on conda-forge or anywhere else I could find on anaconda.org).

Verified by following the updated instructions end-to-end on a clean macOS 26.5 / Apple Silicon machine: `setup.sh` reports all required libraries present and `bcoot` launches cleanly.

## Test plan
- [ ] On a fresh macOS Tahoe / arm64 machine with no prior Miniconda, follow the updated INSTALL.md verbatim and confirm `./setup.sh` prints `ok all required conda libraries present`.
- [ ] Confirm `bcoot` launches and shows the splash + main window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)