### PR TITLE
color-coding of alternate conformations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ ligand/coot-make-ligands-db
 ligand/findligand-bin
 ligand/findwaters-bin
 ligand/identify-protein-bin
+ideal/mini-rsr-bin
+ideal/coot-ligand-validation-bin
 analysis/coot-bfactan
 coot-utils/test-*
 coot-utils/mmrrcc

--- a/coords/Bond_lines.cc
+++ b/coords/Bond_lines.cc
@@ -248,7 +248,8 @@ Bond_lines_container::Bond_lines_container(atom_selection_container_t asc,
 //
 Bond_lines_container::Bond_lines_container(const atom_selection_container_t &SelAtom,
 					   int imol,
-					   Bond_lines_container::bond_representation_type br_type) {
+					   Bond_lines_container::bond_representation_type br_type,
+					   bool draw_hydrogens_flag_in) {
 
    // std::cout << "Bond_lines_container() for B-factors! @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" << std::endl;
 
@@ -256,7 +257,7 @@ Bond_lines_container::Bond_lines_container(const atom_selection_container_t &Sel
    verbose_reporting = 0;
    do_disulfide_bonds_flag = 1;
    udd_has_ca_handle = -1;
-   do_bonds_to_hydrogens = 1;
+   do_bonds_to_hydrogens = draw_hydrogens_flag_in ? 1 : 0; // BANDICOOT: was hard-coded 1
    b_factor_scale = 1.0;
    have_dictionary = 0;
    for_GL_solid_model_rendering = 0;
@@ -273,10 +274,59 @@ Bond_lines_container::Bond_lines_container(const atom_selection_container_t &Sel
 	 try_set_b_factor_scale(SelAtom.mol);
 	 construct_from_asc(SelAtom, imol, 0.01, max_dist, coot::COLOUR_BY_B_FACTOR, 0, model_number, do_rama_markup);
       } else {
-	 if (br_type == Bond_lines_container::COLOUR_BY_USER_DEFINED_COLOURS)
+	 if (br_type == Bond_lines_container::COLOUR_BY_USER_DEFINED_COLOURS) {
 	    construct_from_asc(SelAtom, imol, 0.01, max_dist, coot::COLOUR_BY_USER_DEFINED_COLOURS, 0, model_number, do_rama_markup);
+	 } else {
+	    if (br_type == Bond_lines_container::COLOUR_BY_ALTLOC_MODE) {
+	       // BANDICOOT: "Colour by Alt. Conf.". The altLoc -> index map has to exist
+	       // before any bond is made, because atom_colour() reads it per atom.
+	       set_altloc_colour_index_map(SelAtom);
+	       construct_from_asc(SelAtom, imol, 0.01, max_dist, coot::COLOUR_BY_ALTLOC, 0, model_number, do_rama_markup);
+	    }
+	 }
       }
    }
+}
+
+// BANDICOOT: collect every alt-conf label in the selection and give each one a colour
+// index. The blank altLoc is always 0 (it is the bulk of the molecule and keeps the
+// molecule's own carbon colour); the remaining labels are numbered 1..n in sorted
+// order, so "A" is always index 1 whatever order the atoms were traversed in.
+void
+Bond_lines_container::set_altloc_colour_index_map(const atom_selection_container_t &asc) {
+
+   altloc_colour_index_map.clear();
+   altloc_colour_index_map[""] = 0;
+
+   std::set<std::string> labels;
+   for (int i=0; i<asc.n_selected_atoms; i++) {
+      mmdb::Atom *at = asc.atom_selection[i];
+      if (at) {
+	 std::string alt_conf(at->altLoc);
+	 if (! alt_conf.empty())
+	    labels.insert(alt_conf);
+      }
+   }
+
+   int idx = 1;
+   std::set<std::string>::const_iterator it;
+   for (it=labels.begin(); it!=labels.end(); it++) { // std::set iterates in sorted order
+      altloc_colour_index_map[*it] = idx;
+      idx++;
+   }
+}
+
+// BANDICOOT: 0 (the blank-altLoc/bulk index) for anything we don't have a label for,
+// so an atom added after the map was built can never index off the end of the palette.
+int
+Bond_lines_container::altloc_colour_index(mmdb::Atom *at) const {
+
+   if (! at) return 0;
+   std::map<std::string, int>::const_iterator it =
+      altloc_colour_index_map.find(std::string(at->altLoc));
+   if (it == altloc_colour_index_map.end())
+      return 0;
+   return it->second;
 }
 
 void
@@ -5033,6 +5083,18 @@ Bond_lines_container::atom_colour(mmdb::Atom *at, int bond_colour_type,
    int col = 0;
 
    if (bond_colour_type == coot::COLOUR_BY_MOLECULE) return col; // one colour fits all
+
+   // BANDICOOT: "Colour by Alt. Conf.". Handled up here as an early return so that the
+   // (deeply nested) element/chain logic below is left exactly as it was. Carbons carry
+   // the alt-conf signal; every other element defers to the normal element colouring, so
+   // N is still blue and O is still red whichever conformer they belong to -- the same
+   // bargain COLOUR_BY_CHAIN_C_ONLY makes.
+   if (bond_colour_type == coot::COLOUR_BY_ALTLOC) {
+      std::string element(at->element);
+      if (element == " C") // PDBv3 FIXME (as elsewhere in this function)
+	 return coot::ALTLOC_COLOUR_INDEX_BASE + altloc_colour_index(at);
+      return atom_colour(at, coot::COLOUR_BY_ATOM_TYPE, atom_colour_map_p);
+   }
 
    if (bond_colour_type == coot::COLOUR_BY_CHAIN) {
 

--- a/coords/Bond_lines.h
+++ b/coords/Bond_lines.h
@@ -38,6 +38,7 @@
 
 #include <vector>
 #include <string>
+#include <map> // BANDICOOT: altloc_colour_index_map
 
 #include "geometry/protein-geometry.hh"
 #include "Cartesian.h"
@@ -67,7 +68,22 @@ namespace coot {
 			COLOUR_BY_OCCUPANCY=6,
 			COLOUR_BY_B_FACTOR=7,
 			COLOUR_BY_USER_DEFINED_COLOURS=8,
-                        COLOUR_BY_HYDROPHOBIC_SIDE_CHAIN=9 };
+                        COLOUR_BY_HYDROPHOBIC_SIDE_CHAIN=9,
+                        // BANDICOOT: "Colour by Alt. Conf." -- carbons are shifted in hue
+                        // by their alt-conf index, heteroatoms keep their element colours
+                        // (c.f. COLOUR_BY_CHAIN_C_ONLY). 22 is deliberately the same value
+                        // as coot::COLOUR_BY_ALTLOC_BONDS in the bonds_box_type enum
+                        // (molecule-class-info.h): those two enums are already mixed in
+                        // make_bonds_type_checked() -- see COLOUR_BY_CHAIN_GOODSELL=21 --
+                        // so keeping one concept on one number makes that harmless.
+                        COLOUR_BY_ALTLOC=22 };
+
+   // BANDICOOT: colour-index base for alt-conf-shifted carbons in COLOUR_BY_ALTLOC mode.
+   // Indices 0..12 stay available for the element colours of bond_colours
+   // (mmdb-extras.h), so heteroatoms are coloured exactly as they are in every other
+   // mode; ALTLOC_COLOUR_INDEX_BASE + n means "a carbon in the n'th alt conf",
+   // with n == 0 meaning the blank altLoc (i.e. the bulk of the molecule).
+   const int ALTLOC_COLOUR_INDEX_BASE = 16;
 
    enum hydrophobic_side_chain_t {
                                   HYDROPHOBIC_TYPE_MAIN_CHAIN,
@@ -877,8 +893,17 @@ public:
    enum bond_representation_type { COLOUR_BY_REGULAR_ATOM_MODE=601,
                                    COLOUR_BY_OCCUPANCY=602,
                                    COLOUR_BY_B_FACTOR=603,
-                                   COLOUR_BY_USER_DEFINED_COLOURS=604
+                                   COLOUR_BY_USER_DEFINED_COLOURS=604,
+                                   COLOUR_BY_ALTLOC_MODE=605 // BANDICOOT
    };
+
+   // BANDICOOT: alt-conf label -> colour index, built once per bonds-box construction
+   // by set_altloc_colour_index_map(). std::map so the ordering is the sorted order of
+   // the altLoc labels rather than the order atoms happen to be traversed in -- the
+   // same file must always give the same colours. The blank altLoc is always index 0.
+   std::map<std::string, int> altloc_colour_index_map;
+   void set_altloc_colour_index_map(const atom_selection_container_t &asc);
+   int altloc_colour_index(mmdb::Atom *at) const;
 
    // getting caught out with Bond_lines_container dependencies?
    // We need:  mmdb-extras.h which needs mmdb-manager.h and <string>
@@ -952,8 +977,13 @@ public:
 
    // This is the one for user-defined, occupancy and B-factor representation
    // 
+   // BANDICOOT: draw_hydrogens_flag_in added for COLOUR_BY_ALTLOC_MODE. This
+   // constructor used to hard-code do_bonds_to_hydrogens = 1, so a mode built through
+   // it ignored the molecule's "Draw Hydrogens" setting. Defaulted to true so the
+   // pre-existing user-defined / occupancy / B-factor modes are unchanged.
    Bond_lines_container (const atom_selection_container_t &SelAtom,
-			 int imol, bond_representation_type br_type);
+			 int imol, bond_representation_type br_type,
+			 bool draw_hydrogens_flag_in = true);
 
    explicit Bond_lines_container(int col);
 

--- a/src/c-interface-preferences.cc
+++ b/src/c-interface-preferences.cc
@@ -1017,6 +1017,21 @@ void update_preference_gui() {
       gtk_adjustment_set_value(adjustment, fval1);
       break;
 
+    // BANDICOOT: "Alt. Conf. Colour Scheme"
+    case PREFERENCES_ALTLOC_CONF_A_COLOUR_OFFSET:
+      w = lookup_widget(dialog, "preferences_altloc_conf_a_offset_hscale");
+      fval1 = g.preferences_internal[i].fvalue1;
+      adjustment = gtk_range_get_adjustment(GTK_RANGE(w));
+      gtk_adjustment_set_value(adjustment, fval1);
+      break;
+
+    case PREFERENCES_ALTLOC_COLOUR_DIFFERENCE:
+      w = lookup_widget(dialog, "preferences_altloc_colour_difference_hscale");
+      fval1 = g.preferences_internal[i].fvalue1;
+      adjustment = gtk_range_get_adjustment(GTK_RANGE(w));
+      gtk_adjustment_set_value(adjustment, fval1);
+      break;
+
     case PREFERENCES_BOND_COLOUR_ROTATION_C_ONLY:
       w = lookup_widget(dialog, "preferences_bond_colours_checkbutton");
       if (g.preferences_internal[i].ivalue1 == 1) {

--- a/src/c-interface.cc
+++ b/src/c-interface.cc
@@ -5198,6 +5198,71 @@ void graphics_to_occupancy_representation(int imol) {
    graphics_draw();
 }
 
+/* BANDICOOT: "Colour by Alt. Conf." - bonds coloured by alt conf. */
+void graphics_to_colour_by_altloc_representation(int imol) {
+
+   if (is_valid_model_molecule(imol)) {
+      graphics_info_t::molecules[imol].make_colour_by_altloc_bonds();
+      std::vector<std::string> command_strings;
+      command_strings.push_back("graphics-to-colour-by-altloc-representation");
+      command_strings.push_back(graphics_info_t::int_to_string(imol));
+      add_to_history(command_strings);
+   }
+   else
+      std::cout << "WARNING:: no such valid molecule " << imol
+		<< " in graphics_to_colour_by_altloc_representation"
+		<< std::endl;
+   graphics_draw();
+}
+
+/* BANDICOOT: redraw every molecule currently in "Colour by Alt. Conf." mode. Used by
+   the two colour-scheme setters below; molecules in any other mode are left alone. */
+void redraw_altloc_coloured_molecules() {
+
+   for (int imol=0; imol<graphics_info_t::n_molecules(); imol++)
+      if (is_valid_model_molecule(imol))
+	 if (graphics_info_t::molecules[imol].Bonds_box_type() == coot::COLOUR_BY_ALTLOC_BONDS)
+	    graphics_info_t::molecules[imol].make_colour_by_altloc_bonds();
+   graphics_draw();
+}
+
+/* BANDICOOT: hue offset (degrees) of conf A from the bulk of the molecule in "Colour
+   by Alt. Conf.". The per-molecule spacing is 21 degrees, so the default of 20 keeps a
+   molecule's alt confs roughly within their own slot on the colour wheel. Set it to 0
+   to give conf A the same colour as the bulk, so that only the additional conformers
+   are marked out. */
+void set_altloc_conf_a_colour_offset(float f) {
+
+   graphics_info_t::altloc_conf_a_colour_offset = f;
+   redraw_altloc_coloured_molecules();
+   std::vector<std::string> command_strings;
+   command_strings.push_back("set-altloc-conf-a-colour-offset");
+   command_strings.push_back(graphics_info_t::float_to_string(f));
+   add_to_history(command_strings);
+}
+
+float get_altloc_conf_a_colour_offset() {
+   return graphics_info_t::altloc_conf_a_colour_offset;
+}
+
+/* BANDICOOT: hue difference (degrees) between one alt conf and the next in "Colour by
+   Alt. Conf." -- conf A to conf B, conf B to conf C, and so on. Hue is not
+   perceptually uniform, so a shift that reads clearly around yellow is nearly
+   invisible in the blues; this is the knob for that. */
+void set_altloc_colour_difference(float f) {
+
+   graphics_info_t::altloc_colour_difference = f;
+   redraw_altloc_coloured_molecules();
+   std::vector<std::string> command_strings;
+   command_strings.push_back("set-altloc-colour-difference");
+   command_strings.push_back(graphics_info_t::float_to_string(f));
+   add_to_history(command_strings);
+}
+
+float get_altloc_colour_difference() {
+   return graphics_info_t::altloc_colour_difference;
+}
+
 /*! \brief draw molecule number imol coloured by user-defined atom colours */
 void graphics_to_user_defined_atom_colours_representation(int imol) {
 

--- a/src/c-interface.h
+++ b/src/c-interface.h
@@ -4858,6 +4858,25 @@ void graphics_to_b_factor_representation(int imol);
 void graphics_to_b_factor_cas_representation(int imol);
 /*! \brief draw molecule number imol coloured by occupancy */
 void graphics_to_occupancy_representation(int imol);
+/*! \brief draw molecule number imol coloured by alt conf ("Colour by Alt. Conf.")
+
+   Carbons are shifted in hue by the alt conf they belong to; heteroatoms keep their
+   usual element colours. The shift is relative to the molecule's own bond colour, so
+   the whole family moves together when the bond-colour slider is moved. */
+void graphics_to_colour_by_altloc_representation(int imol);
+/*! \brief redraw every molecule currently in "Colour by Alt. Conf." mode */
+void redraw_altloc_coloured_molecules();
+/*! \brief set the hue offset (degrees) of conf A from the bulk of the molecule in
+    "Colour by Alt. Conf." (default 20; 0 makes conf A match the bulk, so that only the
+    additional conformers are marked out) */
+void set_altloc_conf_a_colour_offset(float f);
+/*! \brief the hue offset (degrees) of conf A from the bulk in "Colour by Alt. Conf." */
+float get_altloc_conf_a_colour_offset();
+/*! \brief set the hue difference (degrees) between one alt conf and the next in
+    "Colour by Alt. Conf." (default 20) */
+void set_altloc_colour_difference(float f);
+/*! \brief the hue difference (degrees) between successive alt confs in "Colour by Alt. Conf." */
+float get_altloc_colour_difference();
 /*! \brief draw molecule number imol in CA+Ligands mode coloured by user-defined atom colours */
 void graphics_to_user_defined_atom_colours_representation(int imol);
 /*! \brief draw molecule number imol all atoms coloured by user-defined atom colours */
@@ -4919,15 +4938,32 @@ int additional_representation_by_string(int imol,  const char *atom_selection,
 /*   representation_types: */
 /*   enum { coot::SIMPLE_LINES, coot::STICKS, coot::BALL_AND_STICK, coot::SURFACE };
 
-  bonds_box_type:
-  enum {  UNSET_TYPE = -1, NORMAL_BONDS=1, CA_BONDS=2, COLOUR_BY_CHAIN_BONDS=3,
-	  CA_BONDS_PLUS_LIGANDS=4, BONDS_NO_WATERS=5, BONDS_SEC_STRUCT_COLOUR=6,
-	  BONDS_NO_HYDROGENS=15,
-	  CA_BONDS_PLUS_LIGANDS_SEC_STRUCT_COLOUR=7,
-	  CA_BONDS_PLUS_LIGANDS_B_FACTOR_COLOUR=14,
-	  COLOUR_BY_MOLECULE_BONDS=8,
-	  COLOUR_BY_RAINBOW_BONDS=9, COLOUR_BY_B_FACTOR_BONDS=10,
-	  COLOUR_BY_OCCUPANCY_BONDS=11};
+  bonds_box_type: a copy of the anonymous enum in src/molecule-class-info.h, listed
+  here in numeric order for reference. Keep the two in step -- this copy had gone stale
+  and was missing 12, 13, 17, 21 and 22. Note that 21 (COLOUR_BY_CHAIN_GOODSELL) and 22
+  (COLOUR_BY_ALTLOC_BONDS) take their values from coot::bond_colour_t in
+  coords/Bond_lines.h rather than from the molecule-class-info.h enum; the two enums are
+  mixed in make_bonds_type_checked(), so one concept is deliberately kept on one number.
+
+  enum {  UNSET_TYPE                                = -1,
+	  NORMAL_BONDS                              =  1,
+	  CA_BONDS                                  =  2,
+	  COLOUR_BY_CHAIN_BONDS                     =  3,
+	  CA_BONDS_PLUS_LIGANDS                     =  4,
+	  BONDS_NO_WATERS                           =  5,
+	  BONDS_SEC_STRUCT_COLOUR                   =  6,
+	  CA_BONDS_PLUS_LIGANDS_SEC_STRUCT_COLOUR   =  7,
+	  COLOUR_BY_MOLECULE_BONDS                  =  8,
+	  COLOUR_BY_RAINBOW_BONDS                   =  9,
+	  COLOUR_BY_B_FACTOR_BONDS                  = 10,
+	  COLOUR_BY_OCCUPANCY_BONDS                 = 11,
+	  COLOUR_BY_USER_DEFINED_COLOURS____BONDS   = 12,
+	  COLOUR_BY_USER_DEFINED_COLOURS_CA_BONDS   = 13,
+	  CA_BONDS_PLUS_LIGANDS_B_FACTOR_COLOUR     = 14,
+	  BONDS_NO_HYDROGENS                        = 15,
+	  CA_BONDS_PLUS_LIGANDS_AND_SIDECHAINS      = 17,
+	  COLOUR_BY_CHAIN_GOODSELL                  = 21,
+	  COLOUR_BY_ALTLOC_BONDS                    = 22};
 
 */
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -6610,6 +6610,34 @@ on_preferences_bond_colours_hscale_value_changed
   set_colour_map_rotation_on_read_pdb(fvalue);
 }
 
+/* BANDICOOT: Alt. Conf. Colour Scheme - hue offset of conf A from the bulk */
+void
+on_preferences_altloc_conf_a_offset_hscale_value_changed
+                                        (GtkRange        *range,
+                                        gpointer         user_data)
+{
+  GtkAdjustment *adjustment;
+  float fvalue;
+  adjustment = gtk_range_get_adjustment(GTK_RANGE(range));
+  fvalue = gtk_adjustment_get_value(adjustment);
+  preferences_internal_change_value_float(PREFERENCES_ALTLOC_CONF_A_COLOUR_OFFSET, fvalue);
+  set_altloc_conf_a_colour_offset(fvalue);
+}
+
+/* BANDICOOT: Alt. Conf. Colour Scheme - hue difference between successive alt confs */
+void
+on_preferences_altloc_colour_difference_hscale_value_changed
+                                        (GtkRange        *range,
+                                        gpointer         user_data)
+{
+  GtkAdjustment *adjustment;
+  float fvalue;
+  adjustment = gtk_range_get_adjustment(GTK_RANGE(range));
+  fvalue = gtk_adjustment_get_value(adjustment);
+  preferences_internal_change_value_float(PREFERENCES_ALTLOC_COLOUR_DIFFERENCE, fvalue);
+  set_altloc_colour_difference(fvalue);
+}
+
 void
 on_preferences_bond_colours_checkbutton_toggled
                                         (GtkToggleButton *togglebutton,

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -2260,6 +2260,17 @@ on_preferences_bond_colours_hscale_value_changed
                                         (GtkRange        *range,
                                         gpointer         user_data);
 
+/* BANDICOOT: Alt. Conf. Colour Scheme sliders */
+void
+on_preferences_altloc_conf_a_offset_hscale_value_changed
+                                        (GtkRange        *range,
+                                        gpointer         user_data);
+
+void
+on_preferences_altloc_colour_difference_hscale_value_changed
+                                        (GtkRange        *range,
+                                        gpointer         user_data);
+
 void
 on_preferences_bond_colours_checkbutton_toggled
                                         (GtkToggleButton *togglebutton,

--- a/src/coot-preferences.h
+++ b/src/coot-preferences.h
@@ -51,6 +51,9 @@
 #define PREFERENCES_FONT_OWN_COLOUR_FLAG          42 // values -1: unset
                                                      //         0: no
                                                      //         1: yes
+// BANDICOOT: "Alt. Conf. Colour Scheme" (Preferences > Bond Colours), both in degrees
+#define PREFERENCES_ALTLOC_CONF_A_COLOUR_OFFSET   43
+#define PREFERENCES_ALTLOC_COLOUR_DIFFERENCE      44
 
 #define MODEL_TOOLBAR                              0
 #define MAIN_TOOLBAR                               1

--- a/src/coot.py
+++ b/src/coot.py
@@ -3275,6 +3275,24 @@ def graphics_to_b_factor_cas_representation(imol):
 def graphics_to_occupancy_representation(imol):
     return _coot.graphics_to_occupancy_representation(imol)
 
+def graphics_to_colour_by_altloc_representation(imol):
+    return _coot.graphics_to_colour_by_altloc_representation(imol)
+
+def redraw_altloc_coloured_molecules():
+    return _coot.redraw_altloc_coloured_molecules()
+
+def set_altloc_conf_a_colour_offset(f):
+    return _coot.set_altloc_conf_a_colour_offset(f)
+
+def get_altloc_conf_a_colour_offset():
+    return _coot.get_altloc_conf_a_colour_offset()
+
+def set_altloc_colour_difference(f):
+    return _coot.set_altloc_colour_difference(f)
+
+def get_altloc_colour_difference():
+    return _coot.get_altloc_colour_difference()
+
 def graphics_to_user_defined_atom_colours_representation(imol):
     return _coot.graphics_to_user_defined_atom_colours_representation(imol)
 

--- a/src/coot_wrap_python.cc
+++ b/src/coot_wrap_python.cc
@@ -40133,6 +40133,116 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_graphics_to_colour_by_altloc_representation(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  ecode1 = SWIG_AsVal_int(swig_obj[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "graphics_to_colour_by_altloc_representation" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  graphics_to_colour_by_altloc_representation(arg1);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_redraw_altloc_coloured_molecules(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "redraw_altloc_coloured_molecules", 0, 0, 0)) SWIG_fail;
+  redraw_altloc_coloured_molecules();
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_set_altloc_conf_a_colour_offset(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  float arg1 ;
+  float val1 ;
+  int ecode1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  ecode1 = SWIG_AsVal_float(swig_obj[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "set_altloc_conf_a_colour_offset" "', argument " "1"" of type '" "float""'");
+  } 
+  arg1 = static_cast< float >(val1);
+  set_altloc_conf_a_colour_offset(arg1);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_get_altloc_conf_a_colour_offset(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  float result;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "get_altloc_conf_a_colour_offset", 0, 0, 0)) SWIG_fail;
+  result = (float)get_altloc_conf_a_colour_offset();
+  resultobj = SWIG_From_float(static_cast< float >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_set_altloc_colour_difference(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  float arg1 ;
+  float val1 ;
+  int ecode1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  ecode1 = SWIG_AsVal_float(swig_obj[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "set_altloc_colour_difference" "', argument " "1"" of type '" "float""'");
+  } 
+  arg1 = static_cast< float >(val1);
+  set_altloc_colour_difference(arg1);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_get_altloc_colour_difference(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  float result;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "get_altloc_colour_difference", 0, 0, 0)) SWIG_fail;
+  result = (float)get_altloc_colour_difference();
+  resultobj = SWIG_From_float(static_cast< float >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_graphics_to_user_defined_atom_colours_representation(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   int arg1 ;
@@ -77712,6 +77822,12 @@ static PyMethodDef SwigMethods[] = {
 	 { "graphics_to_b_factor_representation", _wrap_graphics_to_b_factor_representation, METH_O, NULL},
 	 { "graphics_to_b_factor_cas_representation", _wrap_graphics_to_b_factor_cas_representation, METH_O, NULL},
 	 { "graphics_to_occupancy_representation", _wrap_graphics_to_occupancy_representation, METH_O, NULL},
+	 { "graphics_to_colour_by_altloc_representation", _wrap_graphics_to_colour_by_altloc_representation, METH_O, NULL},
+	 { "redraw_altloc_coloured_molecules", _wrap_redraw_altloc_coloured_molecules, METH_NOARGS, NULL},
+	 { "set_altloc_conf_a_colour_offset", _wrap_set_altloc_conf_a_colour_offset, METH_O, NULL},
+	 { "get_altloc_conf_a_colour_offset", _wrap_get_altloc_conf_a_colour_offset, METH_NOARGS, NULL},
+	 { "set_altloc_colour_difference", _wrap_set_altloc_colour_difference, METH_O, NULL},
+	 { "get_altloc_colour_difference", _wrap_get_altloc_colour_difference, METH_NOARGS, NULL},
 	 { "graphics_to_user_defined_atom_colours_representation", _wrap_graphics_to_user_defined_atom_colours_representation, METH_O, NULL},
 	 { "graphics_to_user_defined_atom_colours_all_atoms_representation", _wrap_graphics_to_user_defined_atom_colours_all_atoms_representation, METH_O, NULL},
 	 { "graphics_molecule_bond_type", _wrap_graphics_molecule_bond_type, METH_O, NULL},

--- a/src/coot_wrap_python_pre.cc
+++ b/src/coot_wrap_python_pre.cc
@@ -40130,6 +40130,116 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_graphics_to_colour_by_altloc_representation(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  ecode1 = SWIG_AsVal_int(swig_obj[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "graphics_to_colour_by_altloc_representation" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  graphics_to_colour_by_altloc_representation(arg1);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_redraw_altloc_coloured_molecules(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "redraw_altloc_coloured_molecules", 0, 0, 0)) SWIG_fail;
+  redraw_altloc_coloured_molecules();
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_set_altloc_conf_a_colour_offset(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  float arg1 ;
+  float val1 ;
+  int ecode1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  ecode1 = SWIG_AsVal_float(swig_obj[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "set_altloc_conf_a_colour_offset" "', argument " "1"" of type '" "float""'");
+  } 
+  arg1 = static_cast< float >(val1);
+  set_altloc_conf_a_colour_offset(arg1);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_get_altloc_conf_a_colour_offset(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  float result;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "get_altloc_conf_a_colour_offset", 0, 0, 0)) SWIG_fail;
+  result = (float)get_altloc_conf_a_colour_offset();
+  resultobj = SWIG_From_float(static_cast< float >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_set_altloc_colour_difference(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  float arg1 ;
+  float val1 ;
+  int ecode1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  ecode1 = SWIG_AsVal_float(swig_obj[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "set_altloc_colour_difference" "', argument " "1"" of type '" "float""'");
+  } 
+  arg1 = static_cast< float >(val1);
+  set_altloc_colour_difference(arg1);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_get_altloc_colour_difference(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  float result;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "get_altloc_colour_difference", 0, 0, 0)) SWIG_fail;
+  result = (float)get_altloc_colour_difference();
+  resultobj = SWIG_From_float(static_cast< float >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_graphics_to_user_defined_atom_colours_representation(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   int arg1 ;
@@ -77709,6 +77819,12 @@ static PyMethodDef SwigMethods[] = {
 	 { "graphics_to_b_factor_representation", _wrap_graphics_to_b_factor_representation, METH_O, NULL},
 	 { "graphics_to_b_factor_cas_representation", _wrap_graphics_to_b_factor_cas_representation, METH_O, NULL},
 	 { "graphics_to_occupancy_representation", _wrap_graphics_to_occupancy_representation, METH_O, NULL},
+	 { "graphics_to_colour_by_altloc_representation", _wrap_graphics_to_colour_by_altloc_representation, METH_O, NULL},
+	 { "redraw_altloc_coloured_molecules", _wrap_redraw_altloc_coloured_molecules, METH_NOARGS, NULL},
+	 { "set_altloc_conf_a_colour_offset", _wrap_set_altloc_conf_a_colour_offset, METH_O, NULL},
+	 { "get_altloc_conf_a_colour_offset", _wrap_get_altloc_conf_a_colour_offset, METH_NOARGS, NULL},
+	 { "set_altloc_colour_difference", _wrap_set_altloc_colour_difference, METH_O, NULL},
+	 { "get_altloc_colour_difference", _wrap_get_altloc_colour_difference, METH_NOARGS, NULL},
 	 { "graphics_to_user_defined_atom_colours_representation", _wrap_graphics_to_user_defined_atom_colours_representation, METH_O, NULL},
 	 { "graphics_to_user_defined_atom_colours_all_atoms_representation", _wrap_graphics_to_user_defined_atom_colours_all_atoms_representation, METH_O, NULL},
 	 { "graphics_molecule_bond_type", _wrap_graphics_molecule_bond_type, METH_O, NULL},

--- a/src/globjects.cc
+++ b/src/globjects.cc
@@ -963,6 +963,10 @@ short int graphics_info_t::rotate_colour_map_on_read_pdb_flag = 1; // do it.
 short int graphics_info_t::rotate_colour_map_on_read_pdb_c_only_flag = 1; // rotate Cs only by default
 float     graphics_info_t::rotate_colour_map_on_read_pdb = 21.0;  // degrees
 float     graphics_info_t::rotate_colour_map_for_map = 14.0;  // degrees
+// BANDICOOT: the two knobs of the "Colour by Alt. Conf." bond mode (degrees).
+// 20/20 reproduces the original single-step behaviour: bulk, +20, +40, ...
+float     graphics_info_t::altloc_conf_a_colour_offset = 20.0;  // degrees
+float     graphics_info_t::altloc_colour_difference    = 20.0;  // degrees
 
 // cell colour
 coot::colour_holder graphics_info_t::cell_colour =

--- a/src/graphics-info-preferences.cc
+++ b/src/graphics-info-preferences.cc
@@ -141,7 +141,19 @@ graphics_info_t::save_preference_file(const std::string &filename, short int il)
        commands.push_back(state_command("set-colour-map-rotation-on-read-pdb-c-only-flag",
 					g.preferences_internal[i].ivalue1, il));
        break;
-       
+
+     // BANDICOOT: "Alt. Conf. Colour Scheme"
+     case PREFERENCES_ALTLOC_CONF_A_COLOUR_OFFSET:
+       commands.push_back(state_command("set-altloc-conf-a-colour-offset",
+					g.preferences_internal[i].fvalue1, il));
+       break;
+
+     case PREFERENCES_ALTLOC_COLOUR_DIFFERENCE:
+       commands.push_back(state_command("set-altloc-colour-difference",
+					g.preferences_internal[i].fvalue1, il));
+       break;
+
+
      case PREFERENCES_MAP_RADIUS:
        commands.push_back(state_command("set-map-radius",
 					 g.preferences_internal[i].fvalue1, il));
@@ -497,7 +509,19 @@ graphics_info_t::make_preferences_internal() {
   p.preference_type = PREFERENCES_BOND_COLOUR_ROTATION_C_ONLY;
   p.ivalue1 = on;
   ret.push_back(p);
-   
+
+  // BANDICOOT: "Alt. Conf. Colour Scheme"
+  fvalue = graphics_info_t::altloc_conf_a_colour_offset;
+  p.preference_type = PREFERENCES_ALTLOC_CONF_A_COLOUR_OFFSET;
+  p.fvalue1 = fvalue;
+  ret.push_back(p);
+
+  fvalue = graphics_info_t::altloc_colour_difference;
+  p.preference_type = PREFERENCES_ALTLOC_COLOUR_DIFFERENCE;
+  p.fvalue1 = fvalue;
+  ret.push_back(p);
+
+
   // Map preference settings
   // Map parameters
   fvalue = get_map_radius();

--- a/src/graphics-info.h
+++ b/src/graphics-info.h
@@ -1200,6 +1200,22 @@ public:
    static short int rotate_colour_map_on_read_pdb_flag;
    static float rotate_colour_map_on_read_pdb; // e.g. 5.0 (degrees)
    static short int rotate_colour_map_on_read_pdb_c_only_flag;
+   // BANDICOOT: the two knobs of the "Colour by Alt. Conf." bond mode, both hue shifts
+   // in degrees, both settable from Preferences > Bond Colours.
+   //
+   //   bulk (blank altLoc) : +0
+   //   conf A              : +altloc_conf_a_colour_offset
+   //   conf B              : +altloc_conf_a_colour_offset + altloc_colour_difference
+   //   conf n              : +altloc_conf_a_colour_offset + (n-1)*altloc_colour_difference
+   //
+   // So the offset decides whether alt-conf regions stand out from the bulk at all
+   // (set it to 0 and conf A is indistinguishable from the bulk, leaving only the
+   // additional conformers marked), and the difference decides how far apart the
+   // conformers are from each other. Defaults are of the same order as
+   // rotate_colour_map_on_read_pdb (the per-molecule spacing), so a molecule's alt confs
+   // read as a family rather than as separate molecules.
+   static float altloc_conf_a_colour_offset;
+   static float altloc_colour_difference;
 
    static float rotate_colour_map_for_map; // e.g. 31.0 (degrees)
 

--- a/src/gtk-manual.cc
+++ b/src/gtk-manual.cc
@@ -630,6 +630,18 @@ void display_control_molecule_combo_box(GtkWidget *display_control_window_glade,
 		     GTK_SIGNAL_FUNC(render_as_sec_struct_bonds_button_select),
 		     GINT_TO_POINTER(n));
 
+ /* BANDICOOT: Now a button for alt-conf-coloured bonds.
+    NOTE: inserted here (menu index 4) rather than appended, so every menu index below
+    this point is one higher than it used to be -- the bond_type -> menu-index mapping
+    at the end of this function was renumbered to match. */
+
+  glade_menuitem = gtk_menu_item_new_with_label (_("Bonds (Colour by Alt. Conf.)"));
+  gtk_widget_show (glade_menuitem);
+  gtk_menu_append (GTK_MENU (render_optionmenu_1_menu), glade_menuitem);
+  gtk_signal_connect(GTK_OBJECT(glade_menuitem), "activate",
+		     GTK_SIGNAL_FUNC(render_as_colour_by_altloc_button_select),
+		     GINT_TO_POINTER(n));
+
  /* Now a button for Ca bonds: */
 
   glade_menuitem = gtk_menu_item_new_with_label (_("C-alphas/Backbone"));
@@ -758,42 +770,47 @@ void display_control_molecule_combo_box(GtkWidget *display_control_window_glade,
      menu = render_optionmenu_1_menu;
      active_item = gtk_menu_get_active(GTK_MENU(menu));
 
-     /*  The conversion between menu item order and bond type (enum) order */
+     /*  The conversion between menu item order and bond type (enum) order.
+         BANDICOOT: renumbered when "Bonds (Colour by Alt. Conf.)" was inserted at
+         index 4 -- every entry that used to be 4 or higher gained one. */
      if (bond_type == 1) { /* atom type bonds */
-       gtk_menu_set_active(GTK_MENU(menu), 0); 
+       gtk_menu_set_active(GTK_MENU(menu), 0);
      }
      if (bond_type == 2) { /* CA bonds */
-       gtk_menu_set_active(GTK_MENU(menu), 4); 
+       gtk_menu_set_active(GTK_MENU(menu), 5);
      }
      if (bond_type == 3) { /* segid-coloured bonds */
-       gtk_menu_set_active(GTK_MENU(menu), 2); 
+       gtk_menu_set_active(GTK_MENU(menu), 2);
      }
      if (bond_type == 4) { /* CA_BONDS_PLUS_LIGANDS */
-       gtk_menu_set_active(GTK_MENU(menu), 5); 
+       gtk_menu_set_active(GTK_MENU(menu), 6);
      }
      if (bond_type == 5) { /* BONDS_NO_WATERS */
-       gtk_menu_set_active(GTK_MENU(menu), 8); 
+       gtk_menu_set_active(GTK_MENU(menu), 9);
      }
      if (bond_type == 6) { /* BONDS_SEC_STRUCT_COLOUR */
-       gtk_menu_set_active(GTK_MENU(menu), 3); 
+       gtk_menu_set_active(GTK_MENU(menu), 3);
      }
      if (bond_type == 7) { /* CA_BONDS_PLUS_LIGANDS_SEC_STRUCT_COLOUR */
-       gtk_menu_set_active(GTK_MENU(menu), 6); 
+       gtk_menu_set_active(GTK_MENU(menu), 7);
      }
      if (bond_type == 8) { /* COLOUR_BY_MOLECULE_BONDS */
-       gtk_menu_set_active(GTK_MENU(menu), 1); 
+       gtk_menu_set_active(GTK_MENU(menu), 1);
      }
      if (bond_type == 9) { /* COLOUR_BY_RAINBOW_BONDS */
-       gtk_menu_set_active(GTK_MENU(menu), 7); 
+       gtk_menu_set_active(GTK_MENU(menu), 8);
      }
      if (bond_type == 10) { /* COLOUR_BY_B_FACTOR_BONDS */
-       gtk_menu_set_active(GTK_MENU(menu), 10); 
+       gtk_menu_set_active(GTK_MENU(menu), 11);
      }
      if (bond_type == 11) { /* COLOUR_BY_OCCUPANCY_BONDS */
-       gtk_menu_set_active(GTK_MENU(menu), 11); 
+       gtk_menu_set_active(GTK_MENU(menu), 12);
      }
      if (bond_type == 14) { /* CA_BONDS_PLUS_LIGANDS_B_FACTOR_COLOUR */
-       gtk_menu_set_active(GTK_MENU(menu), 9); 
+       gtk_menu_set_active(GTK_MENU(menu), 10);
+     }
+     if (bond_type == 22) { /* BANDICOOT COLOUR_BY_ALTLOC_BONDS */
+       gtk_menu_set_active(GTK_MENU(menu), 4);
      }
      /* c.f molecule-class-info.h:30 enum */
   }
@@ -945,6 +962,13 @@ void
 render_as_bonds_colored_by_molecule_button_select(GtkWidget *item, GtkPositionType mol) {
 
   set_colour_by_molecule(mol);
+}
+
+/* BANDICOOT: "Colour by Alt. Conf." - bonds coloured by alt conf. */
+void
+render_as_colour_by_altloc_button_select(GtkWidget *item, GtkPositionType mol) {
+
+  graphics_to_colour_by_altloc_representation(mol);
 }
 
 void

--- a/src/gtk-manual.h
+++ b/src/gtk-manual.h
@@ -162,6 +162,8 @@ void render_as_ca_bonds_button_select(GtkWidget *item, GtkPositionType pos);
 void render_as_ca_plus_ligands_bonds_button_select(GtkWidget *item, GtkPositionType pos);
 void render_as_bonds_colored_by_chain_button_select(GtkWidget *item, GtkPositionType mol);
 void render_as_bonds_colored_by_molecule_button_select(GtkWidget *item, GtkPositionType mol);
+/* BANDICOOT: "Colour by Alt. Conf." - bonds coloured by alt conf */
+void render_as_colour_by_altloc_button_select(GtkWidget *item, GtkPositionType mol);
 void render_as_bonds_no_waters(GtkWidget *item, GtkPositionType mol);
 void render_as_ca_plus_ligands_sec_str_bonds_button_select(GtkWidget *item, GtkPositionType pos);
 void render_as_sec_struct_bonds_button_select(GtkWidget *item, GtkPositionType pos);

--- a/src/gtk2-interface.c
+++ b/src/gtk2-interface.c
@@ -19482,6 +19482,18 @@ create_preferences (void)
   GtkWidget *label497;
   GtkWidget *frame201;
   GtkWidget *preferences_bond_colours_checkbutton;
+  /* BANDICOOT: "Alt. Conf. Colour Scheme" frame */
+  GtkWidget *frame202_altloc;
+  GtkWidget *vbox_altloc_colours;
+  GtkWidget *hbox_altloc_conf_a_offset;
+  GtkWidget *hbox_altloc_colour_difference;
+  GtkWidget *label_altloc_conf_a_offset;
+  GtkWidget *label_altloc_colour_difference;
+  GtkWidget *label_altloc_conf_a_offset_units;
+  GtkWidget *label_altloc_colour_difference_units;
+  GtkWidget *label_altloc_frame;
+  GtkWidget *preferences_altloc_conf_a_offset_hscale;
+  GtkWidget *preferences_altloc_colour_difference_hscale;
   GtkWidget *label498;
   GtkWidget *label479;
   GtkWidget *preferences_map_parameters;
@@ -20594,6 +20606,69 @@ create_preferences (void)
   gtk_container_add (GTK_CONTAINER (frame201), preferences_bond_colours_checkbutton);
   gtk_container_set_border_width (GTK_CONTAINER (preferences_bond_colours_checkbutton), 5);
 
+  /* BANDICOOT: "Alt. Conf. Colour Scheme" -- the two knobs of the
+     "Bonds (Colour by Alt. Conf.)" display mode. Both are hue shifts in degrees.
+     The sliders top out at 180 because a shift beyond half the wheel is the same
+     visual distance coming back the other way. */
+
+  frame202_altloc = gtk_frame_new (NULL);
+  gtk_widget_show (frame202_altloc);
+  gtk_box_pack_start (GTK_BOX (vbox212), frame202_altloc, FALSE, TRUE, 0);
+  gtk_container_set_border_width (GTK_CONTAINER (frame202_altloc), 2);
+
+  vbox_altloc_colours = gtk_vbox_new (FALSE, 0);
+  gtk_widget_show (vbox_altloc_colours);
+  gtk_container_add (GTK_CONTAINER (frame202_altloc), vbox_altloc_colours);
+
+  /* Conf. A colour offset */
+
+  hbox_altloc_conf_a_offset = gtk_hbox_new (FALSE, 0);
+  gtk_widget_show (hbox_altloc_conf_a_offset);
+  gtk_box_pack_start (GTK_BOX (vbox_altloc_colours), hbox_altloc_conf_a_offset, TRUE, TRUE, 0);
+
+  label_altloc_conf_a_offset = gtk_label_new ("  Conf. A colour offset  ");
+  gtk_widget_show (label_altloc_conf_a_offset);
+  gtk_box_pack_start (GTK_BOX (hbox_altloc_conf_a_offset), label_altloc_conf_a_offset, FALSE, FALSE, 0);
+  gtk_label_set_justify (GTK_LABEL (label_altloc_conf_a_offset), GTK_JUSTIFY_CENTER);
+  gtk_misc_set_alignment (GTK_MISC (label_altloc_conf_a_offset), 0.5, 0.95);
+
+  preferences_altloc_conf_a_offset_hscale = gtk_hscale_new (GTK_ADJUSTMENT (gtk_adjustment_new (20, 0, 190.1, 1, 10, 10.1)));
+  gtk_widget_show (preferences_altloc_conf_a_offset_hscale);
+  gtk_box_pack_start (GTK_BOX (hbox_altloc_conf_a_offset), preferences_altloc_conf_a_offset_hscale, TRUE, TRUE, 0);
+
+  label_altloc_conf_a_offset_units = gtk_label_new ("  degrees   ");
+  gtk_widget_show (label_altloc_conf_a_offset_units);
+  gtk_box_pack_start (GTK_BOX (hbox_altloc_conf_a_offset), label_altloc_conf_a_offset_units, FALSE, FALSE, 0);
+  gtk_label_set_justify (GTK_LABEL (label_altloc_conf_a_offset_units), GTK_JUSTIFY_CENTER);
+  gtk_misc_set_alignment (GTK_MISC (label_altloc_conf_a_offset_units), 0.5, 0.95);
+
+  /* Alt. Conf. colour difference */
+
+  hbox_altloc_colour_difference = gtk_hbox_new (FALSE, 0);
+  gtk_widget_show (hbox_altloc_colour_difference);
+  gtk_box_pack_start (GTK_BOX (vbox_altloc_colours), hbox_altloc_colour_difference, TRUE, TRUE, 0);
+
+  label_altloc_colour_difference = gtk_label_new ("  Alt. Conf. colour difference  ");
+  gtk_widget_show (label_altloc_colour_difference);
+  gtk_box_pack_start (GTK_BOX (hbox_altloc_colour_difference), label_altloc_colour_difference, FALSE, FALSE, 0);
+  gtk_label_set_justify (GTK_LABEL (label_altloc_colour_difference), GTK_JUSTIFY_CENTER);
+  gtk_misc_set_alignment (GTK_MISC (label_altloc_colour_difference), 0.5, 0.95);
+
+  preferences_altloc_colour_difference_hscale = gtk_hscale_new (GTK_ADJUSTMENT (gtk_adjustment_new (20, 0, 190.1, 1, 10, 10.1)));
+  gtk_widget_show (preferences_altloc_colour_difference_hscale);
+  gtk_box_pack_start (GTK_BOX (hbox_altloc_colour_difference), preferences_altloc_colour_difference_hscale, TRUE, TRUE, 0);
+
+  label_altloc_colour_difference_units = gtk_label_new ("  degrees   ");
+  gtk_widget_show (label_altloc_colour_difference_units);
+  gtk_box_pack_start (GTK_BOX (hbox_altloc_colour_difference), label_altloc_colour_difference_units, FALSE, FALSE, 0);
+  gtk_label_set_justify (GTK_LABEL (label_altloc_colour_difference_units), GTK_JUSTIFY_CENTER);
+  gtk_misc_set_alignment (GTK_MISC (label_altloc_colour_difference_units), 0.5, 0.95);
+
+  label_altloc_frame = gtk_label_new ("Alt. Conf. Colour Scheme");
+  gtk_widget_show (label_altloc_frame);
+  gtk_frame_set_label_widget (GTK_FRAME (frame202_altloc), label_altloc_frame);
+  gtk_label_set_use_markup (GTK_LABEL (label_altloc_frame), TRUE);
+
   label498 = gtk_label_new ("Colour Map Rotation [Molecule Independent] ");
   gtk_widget_show (label498);
   gtk_frame_set_label_widget (GTK_FRAME (preferences_bond_colours), label498);
@@ -21508,6 +21583,14 @@ create_preferences (void)
   g_signal_connect ((gpointer) preferences_bond_width_combobox, "changed",
                     G_CALLBACK (on_preferences_bond_width_combobox_changed),
                     NULL);
+  /* BANDICOOT: Alt. Conf. Colour Scheme sliders */
+  g_signal_connect ((gpointer) preferences_altloc_conf_a_offset_hscale, "value_changed",
+                    G_CALLBACK (on_preferences_altloc_conf_a_offset_hscale_value_changed),
+                    NULL);
+  g_signal_connect ((gpointer) preferences_altloc_colour_difference_hscale, "value_changed",
+                    G_CALLBACK (on_preferences_altloc_colour_difference_hscale_value_changed),
+                    NULL);
+
   g_signal_connect ((gpointer) preferences_bond_colours_hscale, "value_changed",
                     G_CALLBACK (on_preferences_bond_colours_hscale_value_changed),
                     NULL);
@@ -21843,6 +21926,9 @@ create_preferences (void)
   GLADE_HOOKUP_OBJECT (preferences, hbox287, "hbox287");
   GLADE_HOOKUP_OBJECT (preferences, label496, "label496");
   GLADE_HOOKUP_OBJECT (preferences, preferences_bond_colours_hscale, "preferences_bond_colours_hscale");
+  /* BANDICOOT: looked up by c-interface-preferences.cc to show the stored values */
+  GLADE_HOOKUP_OBJECT (preferences, preferences_altloc_conf_a_offset_hscale, "preferences_altloc_conf_a_offset_hscale");
+  GLADE_HOOKUP_OBJECT (preferences, preferences_altloc_colour_difference_hscale, "preferences_altloc_colour_difference_hscale");
   GLADE_HOOKUP_OBJECT (preferences, label497, "label497");
   GLADE_HOOKUP_OBJECT (preferences, frame201, "frame201");
   GLADE_HOOKUP_OBJECT (preferences, preferences_bond_colours_checkbutton, "preferences_bond_colours_checkbutton");

--- a/src/molecule-class-info.cc
+++ b/src/molecule-class-info.cc
@@ -935,6 +935,63 @@ molecule_class_info_t::set_bond_colour_by_mol_no(int colour_index, bool against_
    bond_colour_internal = {col.col[0], col.col[1], col.col[2]};
 }
 
+// BANDICOOT: "Colour by Alt. Conf." draw-time colouring.
+//
+// The base (blank-altLoc) carbons deliberately get the molecule's *own* carbon colour,
+// so this mode tracks the per-molecule bond-colour slider: move the slider and the whole
+// family -- bulk and alt confs alike -- shifts together, keeping a fixed offset between
+// its members. Each successive alt conf is one altloc_colour_hue_step further round the
+// hue wheel. Heteroatoms never reach the alt-conf branch (see atom_colour()), so N stays
+// blue and O stays red.
+coot::colour_t
+molecule_class_info_t::get_bond_colour_for_altloc_mode(int icol, bool against_a_dark_background) {
+
+   if (icol < coot::ALTLOC_COLOUR_INDEX_BASE) // an element colour, unchanged
+      return get_bond_colour_by_mol_no(icol, against_a_dark_background);
+
+   int altloc_index = icol - coot::ALTLOC_COLOUR_INDEX_BASE;
+
+   coot::colour_t col;
+   if (bonds_rotate_colour_map_flag) {
+      col = get_bond_colour_by_mol_no(CARBON_BOND, against_a_dark_background);
+   } else {
+      // get_bond_colour_by_mol_no() returns its default grey when the rotation flag is
+      // off, which would make every carbon in this mode grey. Use the plain carbon
+      // colour instead, matching the CARBON_BOND arm of that function.
+      if (use_bespoke_grey_colour_for_carbon_atoms) {
+         col = bespoke_carbon_atoms_colour;
+      } else {
+         if (against_a_dark_background)
+            col.set(0.7, 0.7, 0.0);
+         else
+            col.set(0.5, 0.5, 0.0);
+      }
+   }
+
+   if (altloc_index > 0) {
+      // conf A sits at the offset; each conformer after it adds one difference. With the
+      // defaults (20/20) that is the plain 20-degrees-per-conformer ladder; with the
+      // offset at 0, conf A takes the bulk colour and only the extra conformers are marked.
+      float degrees = graphics_info_t::altloc_conf_a_colour_offset +
+                      static_cast<float>(altloc_index - 1) * graphics_info_t::altloc_colour_difference;
+      float rot = degrees / 360.0;
+      while (rot > 1.0) rot -= 1.0; // colour_t::rotate() only wraps once
+      while (rot < 0.0) rot += 1.0;
+      if (rot > 0.0)
+         col.rotate(rot);
+   }
+
+   return col;
+}
+
+void
+molecule_class_info_t::set_bond_colour_for_altloc_mode(int icol, bool against_a_dark_background) {
+
+   coot::colour_t col = get_bond_colour_for_altloc_mode(icol, against_a_dark_background);
+   glColor3f(col[0], col[1], col[2]);
+   bond_colour_internal = {col[0], col[1], col[2]};
+}
+
 void
 molecule_class_info_t::set_bond_colour_for_goodsell_mode(int icol, bool against_a_dark_background) {
 
@@ -2295,7 +2352,11 @@ molecule_class_info_t::display_bonds(const graphical_bonds_container &bonds_box,
                   if (bonds_box_type == coot::COLOUR_BY_CHAIN_GOODSELL) {
                      set_bond_colour_for_goodsell_mode(icol, against_a_dark_background);
                   } else {
-                     set_bond_colour_by_mol_no(icol, against_a_dark_background); // outside inner loop
+                     if (bonds_box_type == coot::COLOUR_BY_ALTLOC_BONDS) { // BANDICOOT
+                        set_bond_colour_for_altloc_mode(icol, against_a_dark_background);
+                     } else {
+                        set_bond_colour_by_mol_no(icol, against_a_dark_background); // outside inner loop
+                     }
                   }
                }
             }
@@ -2564,7 +2625,12 @@ molecule_class_info_t::display_bonds_stick_mode_atoms(const graphical_bonds_cont
                for (int icol=0; icol<bonds_box.n_consolidated_atom_centres; icol++) {
 
                   if (bonds_box.consolidated_atom_centres[icol].num_points == 0) continue;
-                  coot::colour_t cc = get_bond_colour_by_mol_no(icol, against_a_dark_background);
+                  // BANDICOOT: the atom-centre points have to follow the same colour
+                  // rule as the bonds, or the alt-conf carbons get their dots from the
+                  // default (index*26 deg) arm of get_bond_colour_by_mol_no().
+                  coot::colour_t cc = (bonds_box_type == coot::COLOUR_BY_ALTLOC_BONDS)
+                     ? get_bond_colour_for_altloc_mode(icol, against_a_dark_background)
+                     : get_bond_colour_by_mol_no(icol, against_a_dark_background);
                   cc.brighter(1.15);
                   glColor3f(cc[0], cc[1], cc[2]);
 
@@ -3596,6 +3662,28 @@ molecule_class_info_t::make_colour_by_chain_bonds(const std::set<int> &no_bonds_
       graphics_info_t::graphics_draw();
 }
 
+// BANDICOOT: "Colour by Alt. Conf." -- bonds coloured by alt conf.
+//
+// With no _pdbx_heterogeneity_hierarchy present (the only case in the 0.1.x.x line) the
+// alt-conf label IS the state, so this colours by altLoc. When the hierarchy category is
+// read (v0.2.x), the index handed to the colour map becomes the hierarchy node rather
+// than the raw label and nothing here has to change.
+void
+molecule_class_info_t::make_colour_by_altloc_bonds() {
+
+   // the (draw_hydrogens_flag != 0) is deliberate: draw_hydrogens_flag is an int, and
+   // passing it as one makes this call ambiguous against the (asc, imol, int, int, ...)
+   // constructor. An explicit bool picks the bond_representation_type overload cleanly.
+   Bond_lines_container bonds(atom_sel, imol_no, Bond_lines_container::COLOUR_BY_ALTLOC_MODE,
+                              (draw_hydrogens_flag != 0));
+   bonds_box.clear_up();
+   bonds_box = bonds.make_graphical_bonds_no_thinning();
+   bonds_box_type = coot::COLOUR_BY_ALTLOC_BONDS;
+
+   if (graphics_info_t::glarea)
+      graphics_info_t::graphics_draw();
+}
+
 void
 molecule_class_info_t::make_colour_by_molecule_bonds() {
 
@@ -3650,6 +3738,8 @@ molecule_class_info_t::make_bonds_type_checked() {
    }
    if (bonds_box_type == coot::COLOUR_BY_MOLECULE_BONDS)
       make_colour_by_molecule_bonds();
+   if (bonds_box_type == coot::COLOUR_BY_ALTLOC_BONDS) // BANDICOOT
+      make_colour_by_altloc_bonds();
    if (bonds_box_type == coot::CA_BONDS_PLUS_LIGANDS)
       make_ca_plus_ligands_bonds(g.Geom_p());
    if (bonds_box_type == coot::CA_BONDS_PLUS_LIGANDS_AND_SIDECHAINS)

--- a/src/molecule-class-info.h
+++ b/src/molecule-class-info.h
@@ -158,7 +158,12 @@ namespace coot {
 	  COLOUR_BY_B_FACTOR_BONDS=10,
 	  COLOUR_BY_OCCUPANCY_BONDS=11,
 	  COLOUR_BY_USER_DEFINED_COLOURS____BONDS=12,
-	  COLOUR_BY_USER_DEFINED_COLOURS_CA_BONDS=13 };
+	  COLOUR_BY_USER_DEFINED_COLOURS_CA_BONDS=13,
+          // BANDICOOT: "Colour by Alt. Conf.". Same number as coot::COLOUR_BY_ALTLOC in
+          // the bond_colour_t enum (coords/Bond_lines.h) on purpose -- this enum and
+          // that one are already mixed in make_bonds_type_checked() (see
+          // COLOUR_BY_CHAIN_GOODSELL=21), so one concept / one number keeps that safe.
+          COLOUR_BY_ALTLOC_BONDS=22 };
 
    enum { RESIDUE_NUMBER_UNSET = -1111};
 
@@ -906,6 +911,13 @@ public:        //                      public
 					   	                    // we also set
 						                    // bond_colour_internal.
    void set_bond_colour_for_goodsell_mode(int icol, bool against_a_dark_background);
+   // BANDICOOT: draw-time colour for the "Colour by Alt. Conf." mode. Colour indices
+   // below coot::ALTLOC_COLOUR_INDEX_BASE are element colours and are handed to
+   // set_bond_colour_by_mol_no() unchanged; at or above it they are carbons in the
+   // (icol - base)'th alt conf and get the molecule's carbon colour rotated by that
+   // many hue steps.
+   coot::colour_t get_bond_colour_for_altloc_mode(int icol, bool against_a_dark_background);
+   void set_bond_colour_for_altloc_mode(int icol, bool against_a_dark_background);
 
    // return the colour, don't call glColor3f();
    coot::colour_t get_bond_colour_by_mol_no(int icolour, bool against_a_dark_background);
@@ -1171,6 +1183,7 @@ public:        //                      public
    void make_ca_plus_ligands_and_sidechains_bonds(coot::protein_geometry *pg);
    void make_colour_by_chain_bonds(const std::set<int> &no_bonds_to_these_atoms, bool c_only_flag, bool goodsell_mode);
    void make_colour_by_molecule_bonds();
+   void make_colour_by_altloc_bonds(); // BANDICOOT: "Colour by Alt. Conf."
    void bonds_no_waters_representation();
    void bonds_sec_struct_representation();
    void ca_plus_ligands_sec_struct_representation(coot::protein_geometry *pg);


### PR DESCRIPTION
This is new code that adds another style of coloring: Color by Alt. Conf. The default look shifts the coloring of residues with alternate conformations; conf A is shifted by 20° from the bulk model color, while conf B is shifted by 20° from conf A. Both shifts are adjustable in Preferences -> Bonds -> Bond Colours, so that users can create the look they want.

The idea is to help users a) find regions with altlocs at a glance and b) develop a visual shorthand for conformational hierarchy, i.e. which is conf A, which is conf B, etc. This functionality is designed to accommodate future work on hierarchical heterogeneity encoding.